### PR TITLE
monitor: refine log formats

### DIFF
--- a/opensbi-0.9/lib/sbi/sm/enclave.c
+++ b/opensbi-0.9/lib/sbi/sm/enclave.c
@@ -733,7 +733,7 @@ uintptr_t enclave_sys_write(uintptr_t* regs)
 	struct enclave_t* enclave = NULL;
 	if(check_in_enclave_world() < 0)
 	{
-		printm("M mode: %s check enclave world is failed\n", __func__);
+		printm_err("[Penglai Monitor@%s] check enclave world is failed\n", __func__);
 		return -1;
 	}
 
@@ -741,7 +741,7 @@ uintptr_t enclave_sys_write(uintptr_t* regs)
 	if(!enclave || check_enclave_authentication(enclave)!=0 || enclave->state != RUNNING)
 	{
 		ret = -1UL;
-		printm("M mode: %s check enclave authentication is failed\n", __func__);
+		printm_err("[Penglai Monitor@%s] check enclave authentication is failed\n", __func__);
 		goto out;
 	}
 

--- a/opensbi-0.9/lib/sbi/sm/sm.c
+++ b/opensbi-0.9/lib/sbi/sm/sm.c
@@ -196,6 +196,7 @@ uintptr_t sm_enclave_ocall(uintptr_t* regs, uintptr_t ocall_id, uintptr_t arg0, 
       ret = enclave_sys_write(regs);
       break;
     default:
+      printm_err("[Penglai Monitor@%s] wrong ocall_id(%ld)\r\n", __func__, ocall_id);
       ret = -1UL;
       break;
   }


### PR DESCRIPTION
Refine the error msg formats and turns to use printm_err.

Signed-off-by: Dong Du <dd_nirvana@sjtu.edu.cn>