### PR TITLE
Replace hard-coded SM_BASE/SM_SIZE with definitions in payload linker script

### DIFF
--- a/opensbi-0.9/include/sm/sm.h
+++ b/opensbi-0.9/include/sm/sm.h
@@ -11,12 +11,10 @@
 #include <stdint.h>
 #include <sm/enclave_args.h>
 
-/*
- * Note: the hard-coded SM base and size depends on the M-mode firmware,
- * 	 e.g., in OpenSBI, you should check the firmware range in platform/generic/config.mk
- * */
-#define SM_BASE 0x80000000
-#define SM_SIZE 0x200000
+extern uintptr_t _fw_start[], _fw_end[];
+
+#define SM_BASE ((uintptr_t) _fw_start)
+#define SM_SIZE (((uintptr_t) _fw_end) - ((uintptr_t) _fw_start))
 
 #define MAX_HARTS 8
 


### PR DESCRIPTION
Replace hard-coded SM_BASE/SM_SIZE with _fw_start/_fw_end in payload linker script

Signed-off-by: Liang Liang <liangliang@trustkernel.com>
Reviewed-by: Dong Du <Dd_nirvana@sjtu.edu.cn>