### PR TITLE
fix Kernel panic

### DIFF
--- a/opensbi-1.2/lib/sbi/sm/sm.c
+++ b/opensbi-1.2/lib/sbi/sm/sm.c
@@ -12,213 +12,216 @@
 
 void sm_init()
 {
-  printm("[Penglai Monitor] %s invoked\r\n",__func__);
-  platform_init();
-  attest_init();
+	printm("[Penglai Monitor] %s invoked\r\n", __func__);
+	platform_init();
+	attest_init();
 }
 
 uintptr_t sm_mm_init(uintptr_t paddr, unsigned long size)
 {
-  uintptr_t retval = 0;
+	uintptr_t retval = 0;
 
-  printm("[Penglai Monitor] %s invoked\r\n",__func__);
+	printm("[Penglai Monitor] %s invoked\r\n", __func__);
 
-  printm("[Penglai Monitor] %s paddr:0x%lx, size:0x%lx\r\n",__func__, paddr, size);
-  /*DEBUG: Dump PMP registers here */
-  dump_pmps();
-  retval = mm_init(paddr, size);
-  /*DEBUG: Dump PMP registers here */
-  dump_pmps();
+	printm("[Penglai Monitor] %s paddr:0x%lx, size:0x%lx\r\n", __func__,
+	       paddr, size);
+	/*DEBUG: Dump PMP registers here */
+	dump_pmps();
+	retval = mm_init(paddr, size);
+	/*DEBUG: Dump PMP registers here */
+	dump_pmps();
 
-  printm("[Penglai Monitor] %s ret:%ld \r\n",__func__, retval);
-  return retval;
+	printm("[Penglai Monitor] %s ret:%ld \r\n", __func__, retval);
+	return retval;
 }
 
 uintptr_t sm_mm_extend(uintptr_t paddr, unsigned long size)
 {
-  uintptr_t retval = 0;
-  printm("[Penglai Monitor] %s invoked\r\n",__func__);
+	uintptr_t retval = 0;
+	printm("[Penglai Monitor] %s invoked\r\n", __func__);
 
-  retval = mm_init(paddr, size);
+	retval = mm_init(paddr, size);
 
-  printm("[Penglai Monitor] %s return:%ld\r\n",__func__, retval);
-  return retval;
+	printm("[Penglai Monitor] %s return:%ld\r\n", __func__, retval);
+	return retval;
 }
 
-uintptr_t sm_debug_print(uintptr_t* regs, uintptr_t arg0)
+uintptr_t sm_debug_print(uintptr_t *regs, uintptr_t arg0)
 {
-  print_buddy_system();
-  return 0;
+	print_buddy_system();
+	return 0;
 }
 
 uintptr_t sm_alloc_enclave_mem(uintptr_t mm_alloc_arg)
 {
-  struct mm_alloc_arg_t mm_alloc_arg_local;
-  uintptr_t retval = 0;
+	struct mm_alloc_arg_t mm_alloc_arg_local;
+	uintptr_t retval = 0;
 
-  printm("[Penglai Monitor] %s invoked\r\n",__func__);
+	printm("[Penglai Monitor] %s invoked\r\n", __func__);
 
-  retval = copy_from_host(&mm_alloc_arg_local,
-      (struct mm_alloc_arg_t*)mm_alloc_arg,
-      sizeof(struct mm_alloc_arg_t));
-  if(retval != 0)
-  {
-    printm_err("M mode: sm_alloc_enclave_mem: unknown error happended when copy from host\r\n");
-    return ENCLAVE_ERROR;
-  }
+	retval = copy_from_host(&mm_alloc_arg_local,
+				(struct mm_alloc_arg_t *)mm_alloc_arg,
+				sizeof(struct mm_alloc_arg_t));
+	if (retval != 0) {
+		printm_err(
+			"M mode: sm_alloc_enclave_mem: unknown error happended when copy from host\r\n");
+		return ENCLAVE_ERROR;
+	}
 
-  dump_pmps();
-  unsigned long resp_size = 0;
-  void* paddr = mm_alloc(mm_alloc_arg_local.req_size, &resp_size);
-  if(paddr == NULL)
-  {
-    printm("M mode: sm_alloc_enclave_mem: no enough memory\r\n");
-    return ENCLAVE_NO_MEMORY;
-  }
-  dump_pmps();
+	dump_pmps();
+	unsigned long resp_size = 0;
+	void *paddr = mm_alloc(mm_alloc_arg_local.req_size, &resp_size);
+	if (paddr == NULL) {
+		printm("M mode: sm_alloc_enclave_mem: no enough memory\r\n");
+		return ENCLAVE_NO_MEMORY;
+	}
+	dump_pmps();
 
-  //grant kernel access to this memory
-  if(grant_kernel_access(paddr, resp_size) != 0)
-  {
-    printm_err("M mode: ERROR: faile to grant kernel access to pa 0x%lx, size 0x%lx\r\n", (unsigned long) paddr, resp_size);
-    mm_free(paddr, resp_size);
-    return ENCLAVE_ERROR;
-  }
+	//grant kernel access to this memory
+	if (grant_kernel_access(paddr, resp_size) != 0) {
+		printm_err(
+			"M mode: ERROR: faile to grant kernel access to pa 0x%lx, size 0x%lx\r\n",
+			(unsigned long)paddr, resp_size);
+		mm_free(paddr, resp_size);
+		return ENCLAVE_ERROR;
+	}
 
-  mm_alloc_arg_local.resp_addr = (uintptr_t)paddr;
-  mm_alloc_arg_local.resp_size = resp_size;
+	mm_alloc_arg_local.resp_addr = (uintptr_t)paddr;
+	mm_alloc_arg_local.resp_size = resp_size;
 
-  retval = copy_to_host((struct mm_alloc_arg_t*)mm_alloc_arg,
-      &mm_alloc_arg_local,
-      sizeof(struct mm_alloc_arg_t));
-  if(retval != 0)
-  {
-    printm_err("M mode: sm_alloc_enclave_mem: unknown error happended when copy to host\r\n");
-    return ENCLAVE_ERROR;
-  }
+	retval = copy_to_host((struct mm_alloc_arg_t *)mm_alloc_arg,
+			      &mm_alloc_arg_local,
+			      sizeof(struct mm_alloc_arg_t));
+	if (retval != 0) {
+		printm_err(
+			"M mode: sm_alloc_enclave_mem: unknown error happended when copy to host\r\n");
+		return ENCLAVE_ERROR;
+	}
 
-  printm("[Penglai Monitor] %s return:%ld\r\n",__func__, retval);
+	printm("[Penglai Monitor] %s return:%ld\r\n", __func__, retval);
 
-  return ENCLAVE_SUCCESS;
+	return ENCLAVE_SUCCESS;
 }
 
 uintptr_t sm_create_enclave(uintptr_t enclave_sbi_param)
 {
-  struct enclave_sbi_param_t enclave_sbi_param_local;
-  uintptr_t retval = 0;
+	struct enclave_sbi_param_t enclave_sbi_param_local;
+	uintptr_t retval = 0;
 
-  printm("[Penglai Monitor] %s invoked\r\n",__func__);
+	printm("[Penglai Monitor] %s invoked\r\n", __func__);
 
-  retval = copy_from_host(&enclave_sbi_param_local,
-      (struct enclave_sbi_param_t*)enclave_sbi_param,
-      sizeof(struct enclave_sbi_param_t));
-  if(retval != 0)
-  {
-    printm_err("M mode: sm_create_enclave: unknown error happended when copy from host\r\n");
-    return ENCLAVE_ERROR;
-  }
+	retval = copy_from_host(&enclave_sbi_param_local,
+				(struct enclave_sbi_param_t *)enclave_sbi_param,
+				sizeof(struct enclave_sbi_param_t));
+	if (retval != 0) {
+		printm_err(
+			"M mode: sm_create_enclave: unknown error happended when copy from host\r\n");
+		return ENCLAVE_ERROR;
+	}
 
-  void* paddr = (void*)enclave_sbi_param_local.paddr;
-  unsigned long size = (unsigned long)enclave_sbi_param_local.size;
-  if(retrieve_kernel_access(paddr, size) != 0)//we always allow kernel access the memory now
-  {
-    mm_free(paddr, size);
-    return -1UL;
-  }
+	void *paddr	   = (void *)enclave_sbi_param_local.paddr;
+	unsigned long size = (unsigned long)enclave_sbi_param_local.size;
+	if (retrieve_kernel_access(paddr, size) !=
+	    0) //we always allow kernel access the memory now
+	{
+		mm_free(paddr, size);
+		return -1UL;
+	}
 
-  retval = create_enclave(enclave_sbi_param_local);
+	retval = create_enclave(enclave_sbi_param_local);
 
-  printm("[Penglai Monitor] %s created return value:%ld \r\n",__func__, retval);
-  return retval;
+	printm("[Penglai Monitor] %s created return value:%ld \r\n", __func__,
+	       retval);
+	return retval;
 }
 
 uintptr_t sm_attest_enclave(uintptr_t eid, uintptr_t report, uintptr_t nonce)
 {
-  uintptr_t retval;
-  printm("[Penglai Monitor] %s invoked, eid:%ld\r\n",__func__, eid);
+	uintptr_t retval;
+	printm("[Penglai Monitor] %s invoked, eid:%ld\r\n", __func__, eid);
 
-  retval = attest_enclave(eid, report, nonce);
+	retval = attest_enclave(eid, report, nonce);
 
-  printm("[Penglai Monitor] %s return: %ld\r\n",__func__, retval);
+	printm("[Penglai Monitor] %s return: %ld\r\n", __func__, retval);
 
-  return retval;
+	return retval;
 }
 
-uintptr_t sm_run_enclave(uintptr_t* regs, unsigned long eid)
+uintptr_t sm_run_enclave(uintptr_t *regs, unsigned long eid)
 {
-  uintptr_t retval;
-  printm("[Penglai Monitor] %s invoked, eid:%ld\r\n",__func__, eid);
+	uintptr_t retval;
+	printm("[Penglai Monitor] %s invoked, eid:%ld\r\n", __func__, eid);
 
-  retval = run_enclave(regs, (unsigned int)eid);
+	retval = run_enclave(regs, (unsigned int)eid);
 
-  printm("[Penglai Monitor] %s return: %ld\r\n",__func__, retval);
+	printm("[Penglai Monitor] %s return: %ld\r\n", __func__, retval);
 
-  return retval;
+	return retval;
 }
 
-uintptr_t sm_stop_enclave(uintptr_t* regs, unsigned long eid)
+uintptr_t sm_stop_enclave(uintptr_t *regs, unsigned long eid)
 {
-  uintptr_t retval;
-  printm("[Penglai Monitor] %s invoked, eid:%ld\r\n",__func__, eid);
+	uintptr_t retval;
+	printm("[Penglai Monitor] %s invoked, eid:%ld\r\n", __func__, eid);
 
-  retval = stop_enclave(regs, (unsigned int)eid);
+	retval = stop_enclave(regs, (unsigned int)eid);
 
-  printm("[Penglai Monitor] %s return: %ld\r\n",__func__, retval);
-  return retval;
+	printm("[Penglai Monitor] %s return: %ld\r\n", __func__, retval);
+	return retval;
 }
 
-uintptr_t sm_resume_enclave(uintptr_t* regs, unsigned long eid)
+uintptr_t sm_resume_enclave(uintptr_t *regs, unsigned long eid)
 {
-  uintptr_t retval = 0;
-  uintptr_t resume_func_id = regs[11];
+	uintptr_t retval	 = 0;
+	uintptr_t resume_func_id = regs[11];
 
-  switch(resume_func_id)
-  {
-    case RESUME_FROM_TIMER_IRQ:
-      retval = resume_enclave(regs, eid);
-      break;
-    case RESUME_FROM_STOP:
-      retval = resume_from_stop(regs, eid);
-      break;
-    case RESUME_FROM_OCALL:
-      retval = resume_from_ocall(regs, eid);
-      break;
-    default:
-      break;
-  }
+	switch (resume_func_id) {
+	case RESUME_FROM_TIMER_IRQ:
+		retval = resume_enclave(regs, eid);
+		break;
+	case RESUME_FROM_STOP:
+		retval = resume_from_stop(regs, eid);
+		break;
+	case RESUME_FROM_OCALL:
+		retval = resume_from_ocall(regs, eid);
+		break;
+	default:
+		break;
+	}
 
-  return retval;
+	return retval;
 }
 
-uintptr_t sm_exit_enclave(uintptr_t* regs, unsigned long retval)
+uintptr_t sm_exit_enclave(uintptr_t *regs, unsigned long retval)
 {
-  uintptr_t ret;
-  printm("[Penglai Monitor] %s invoked\r\n",__func__);
+	uintptr_t ret;
+	printm("[Penglai Monitor] %s invoked\r\n", __func__);
 
-  ret = exit_enclave(regs, retval);
+	ret = exit_enclave(regs, retval);
 
-  printm("[Penglai Monitor] %s return: %ld\r\n",__func__, ret);
+	printm("[Penglai Monitor] %s return: %ld\r\n", __func__, ret);
 
-  return ret;
+	return ret;
 }
 
-uintptr_t sm_enclave_ocall(uintptr_t* regs, uintptr_t ocall_id, uintptr_t arg0, uintptr_t arg1)
+uintptr_t sm_enclave_ocall(uintptr_t *regs, uintptr_t ocall_id, uintptr_t arg0,
+			   uintptr_t arg1)
 {
-  uintptr_t ret = 0;
-  switch(ocall_id)
-  {
-    case OCALL_SYS_WRITE:
-      ret = enclave_sys_write(regs);
-      break;
-    case OCALL_USER_DEFINED:
-      ret = enclave_user_defined_ocall(regs, arg0);
-      break;
-    default:
-      printm_err("[Penglai Monitor@%s] wrong ocall_id(%ld)\r\n", __func__, ocall_id);
-      ret = -1UL;
-      break;
-  }
-  return ret;
+	uintptr_t ret = 0;
+	switch (ocall_id) {
+	case OCALL_SYS_WRITE:
+		ret = enclave_sys_write(regs);
+		break;
+	case OCALL_USER_DEFINED:
+		ret = enclave_user_defined_ocall(regs, arg0);
+		break;
+	default:
+		printm_err("[Penglai Monitor@%s] wrong ocall_id(%ld)\r\n",
+			   __func__, ocall_id);
+		ret = -1UL;
+		break;
+	}
+	return ret;
 }
 
 /**
@@ -230,14 +233,16 @@ uintptr_t sm_enclave_ocall(uintptr_t* regs, uintptr_t ocall_id, uintptr_t arg0, 
  * \param key_buf_va    Key buffer pointer in enclave address space.
  * \param key_buf_len   Key buffer length in bytes.
  */
-uintptr_t sm_enclave_get_key(uintptr_t* regs, uintptr_t salt_va, uintptr_t salt_len,
-    uintptr_t key_buf_va, uintptr_t key_buf_len)
+uintptr_t sm_enclave_get_key(uintptr_t *regs, uintptr_t salt_va,
+			     uintptr_t salt_len, uintptr_t key_buf_va,
+			     uintptr_t key_buf_len)
 {
-  uintptr_t ret = 0;
+	uintptr_t ret = 0;
 
-  ret = enclave_derive_seal_key(regs, salt_va, salt_len, key_buf_va, key_buf_len);
+	ret = enclave_derive_seal_key(regs, salt_va, salt_len, key_buf_va,
+				      key_buf_len);
 
-  return ret;
+	return ret;
 }
 
 /**
@@ -248,23 +253,23 @@ uintptr_t sm_enclave_get_key(uintptr_t* regs, uintptr_t salt_va, uintptr_t salt_
  */
 uintptr_t sm_destroy_enclave(uintptr_t *regs, uintptr_t enclave_id)
 {
-  uintptr_t ret = 0;
-  printm("[Penglai Monitor] %s invoked\r\n",__func__);
+	uintptr_t ret = 0;
+	printm("[Penglai Monitor] %s invoked\r\n", __func__);
 
-  ret = destroy_enclave(regs, enclave_id);
+	ret = destroy_enclave(regs, enclave_id);
 
-  printm("[Penglai Monitor] %s return: %ld\r\n",__func__, ret);
+	printm("[Penglai Monitor] %s return: %ld\r\n", __func__, ret);
 
-  return ret;
+	return ret;
 }
 
 uintptr_t sm_do_timer_irq(uintptr_t *regs, uintptr_t mcause, uintptr_t mepc)
 {
-  uintptr_t ret;
+	uintptr_t ret;
 
-  ret = do_timer_irq(regs, mcause, mepc);
+	ret = do_timer_irq(regs, mcause, mepc);
 
-  regs[10] = 0; //no errors in all cases for timer handler
-  regs[11] = ret; //value
-  return ret;
+	regs[10] = 0;	//no errors in all cases for timer handler
+	regs[11] = ret; //value
+	return ret;
 }

--- a/penglai-enclave-driver/penglai-enclave.c
+++ b/penglai-enclave-driver/penglai-enclave.c
@@ -76,7 +76,7 @@ enclave_t* create_enclave(int total_pages)
 	while(ret.value == ENCLAVE_NO_MEMORY)
 	{
 		//TODO: allocate certain memory region like sm_init instead of allocating size of one enclave
-		addr = __get_free_pages(GFP_HIGHUSER, order);
+		addr = __get_free_pages(GFP_ATOMIC, order);
 		if(!addr)
 		{
 			printk("KERNEL MODULE: can not get free page which order is 0x%lx", order);
@@ -113,7 +113,7 @@ enclave_t* create_enclave(int total_pages)
 	enclave->enclave_mem = enclave_mem;
 	enclave->untrusted_mem = untrusted_mem;
 
-    kfree(untrusted_mem);
+    kfree(require_sec_memory);
 	spin_unlock_bh(&kmalloc_enclave_lock);
 	//TODO: create untrusted mem
 
@@ -124,7 +124,7 @@ free_enclave:
 	if(enclave) kfree(enclave);
 	if(enclave_mem) kfree(enclave_mem);
 	if(untrusted_mem) kfree(untrusted_mem);
-    if(require_sec_memory) kfree(untrusted_mem);
+    if(require_sec_memory) kfree(require_sec_memory);
 
 	return NULL;
 }
@@ -143,9 +143,8 @@ int destroy_enclave(enclave_t* enclave)
 	enclave_mem = enclave->enclave_mem;
 	untrusted_mem = enclave->untrusted_mem;
 	enclave_mem_destroy(enclave_mem);
-
-	kfree(enclave_mem);
-	kfree(untrusted_mem);
+	if(enclave_mem)kfree(enclave_mem);
+	if(untrusted_mem)kfree(untrusted_mem);
 	kfree(enclave);
 
 	return 0;

--- a/penglai-enclave-driver/penglai-enclave.h
+++ b/penglai-enclave-driver/penglai-enclave.h
@@ -28,7 +28,8 @@
 #define SBI_SM_DESTROY_ENCLAVE           94
 #define SBI_SM_ALLOC_ENCLAVE_MEM         93
 #define SBI_SM_MEMORY_EXTEND             92
-#define SBI_SM_FREE_ENCLAVE_MEM          91
+#define SBI_SM_MEMORY_RECLAIM      		 91
+#define SBI_SM_FREE_ENCLAVE_MEM          90
 #define SBI_SM_DEBUG_PRINT               88
 
 //Error codes of SBI_SM_ALLOC_ENCLAVE_MEM


### PR DESCRIPTION
🐞 fix(penglai-enclave-driver): 

Add a sbi call to reclaim memory and clear pmp settings when uninstalling the pontoon module; add the release operation for kmalloc data.

Mainly for issue: [Facing kernel panic for openEuler 23.09](https://github.com/Penglai-Enclave/Penglai-Enclave-sPMP/issues/100)

_There are no changes to the file opensbi-1.2/lib/sbi/sm/sm.c, just a change in the code formatting._