### PR TITLE
🐞 fix(penglai-enclave-driver): free metadata, secure mem and pmp  issues#100

### DIFF
--- a/penglai-enclave-driver/penglai-enclave-driver.c
+++ b/penglai-enclave-driver/penglai-enclave-driver.c
@@ -11,6 +11,13 @@ MODULE_DESCRIPTION("enclave_ioctl");
 MODULE_AUTHOR("LuXu");
 MODULE_VERSION("enclave_ioctl");
 
+// #define PENGLAI_DEBUG
+#ifdef PENGLAI_DEBUG
+#define dprint(...) printk(__VA_ARGS__)
+#else
+#define dprint(...)
+#endif
+
 static int enclave_mmap(struct file* f,struct vm_area_struct *vma)
 {
 	return 0;
@@ -102,7 +109,7 @@ void enclave_ioctl_exit(void)
 		{
 			free_pages((long unsigned int)__va(addr), (order - RISCV_PGSHIFT));
 		}
-
+		*size = 0;
 		sbiret = SBI_CALL_2(SBI_SM_FREE_ENCLAVE_MEM, __pa(size), FREE_MAX_MEMORY);
 
 		addr = (unsigned long)(sbiret.value);

--- a/penglai-enclave-driver/penglai-enclave-elfloader.c
+++ b/penglai-enclave-driver/penglai-enclave-elfloader.c
@@ -1,4 +1,21 @@
 #include "penglai-enclave-elfloader.h"
+#define	ROUND_TO(x, align)  (((x) + ((align)-1)) & ~((align)-1))
+
+// Function to print hex data
+static void print_hex(const void *data, size_t size) {
+    const unsigned char *byte_data = data;
+    size_t i;
+
+    for (i = 0; i < size; ) {
+        printk("%02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x\n%02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x", 
+		byte_data[i++],byte_data[i++],byte_data[i++],byte_data[i++],byte_data[i++],byte_data[i++],byte_data[i++],byte_data[i++],
+		byte_data[i++],byte_data[i++],byte_data[i++],byte_data[i++],byte_data[i++],byte_data[i++],byte_data[i++],byte_data[i++],
+		byte_data[i++],byte_data[i++],byte_data[i++],byte_data[i++],byte_data[i++],byte_data[i++],byte_data[i++],byte_data[i++],
+		byte_data[i++],byte_data[i++],byte_data[i++],byte_data[i++],byte_data[i++],byte_data[i++],byte_data[i++],byte_data[i++]);
+    }
+    if (i % 16 != 0)
+        printk("\n");
+}
 
 int penglai_enclave_load_NOBITS_section(enclave_mem_t* enclave_mem, void * elf_sect_addr, int elf_sect_size)
 {
@@ -25,8 +42,9 @@ int penglai_enclave_load_program(enclave_mem_t* enclave_mem, vaddr_t elf_prog_in
 {
 	vaddr_t addr;
 	vaddr_t enclave_new_page;
+	vaddr_t begin_page = 0;
 	int size;
-	int r;
+	unsigned long r = 0;
 	for(addr =  (vaddr_t)elf_prog_addr; addr <  (vaddr_t)elf_prog_addr + elf_prog_size; addr += RISCV_PGSIZE)
 	{
 
@@ -35,8 +53,17 @@ int penglai_enclave_load_program(enclave_mem_t* enclave_mem, vaddr_t elf_prog_in
 			size = elf_prog_size % RISCV_PGSIZE;
 		else
 			size = RISCV_PGSIZE;
-		r = copy_from_user((void* )enclave_new_page, (void *)(elf_prog_infile_addr + addr - (vaddr_t)elf_prog_addr), size);
+		r += copy_from_user((void* )enclave_new_page, (void *)(elf_prog_infile_addr + addr - (vaddr_t)elf_prog_addr), size);
+		if (r)
+		{
+			printk("KERNEL MODULE:  load_program copy_from_user failed r=0x%lx\n",r);
+		}
+		
+		// dprint("[Penglai Driver@%s]copy segment 0x%lx to va:0x%lx -pa:0x%lx \n",__func__ ,(unsigned long)((void *)(elf_prog_addr + addr - (vaddr_t)elf_prog_addr)) ,(vaddr_t)enclave_new_page ,__pa((vaddr_t)enclave_new_page));	
+		if(!begin_page)begin_page = enclave_new_page;
+		// print_hex(enclave_new_page, size);
 	}
+	dprint("[Penglai Driver@%s] SUCCESS! from 0x%lx to 0x%lx r=0x%x\n",__func__,(unsigned long)elf_prog_addr,(unsigned long)(elf_prog_addr + elf_prog_size) ,r);
 	return 0;
 }
 
@@ -109,8 +136,8 @@ int penglai_enclave_loadelf(enclave_mem_t*enclave_mem, void* __user elf_ptr, uns
 			printk("KERNEL MODULE: penglai enclave load program failed\n");
 			return -1;
 		}
-		printk("[Penglai Driver@%s] elf_prog_addr:0x%lx elf_prog_size:0x%x, infile_addr:0x%lx", __func__,
-				elf_prog_addr, elf_prog_size, elf_prog_infile_addr);
+		// printk("[Penglai Driver@%s] elf_prog_addr:0x%lx elf_prog_size:0x%x, infile_addr:0x%lx", __func__,
+				// elf_prog_addr, elf_prog_size, elf_prog_infile_addr);
 		elf_prog_ptr += sizeof(struct elf_phdr);
 	}
 	return 0;

--- a/penglai-enclave-driver/penglai-enclave-ioctl.h
+++ b/penglai-enclave-driver/penglai-enclave-ioctl.h
@@ -20,8 +20,10 @@
 	_IOW(PENGLAI_ENCLAVE_IOC_MAGIC, 0x05, struct penglai_enclave_user_param)
 #define PENGLAI_ENCLAVE_IOC_DEBUG_PRINT \
 	_IOW(PENGLAI_ENCLAVE_IOC_MAGIC, 0x06, struct penglai_enclave_user_param)
+#define PENGLAI_ENCLAVE_MEMORY_RECLAIM \
+  _IOW(PENGLAI_ENCLAVE_IOC_MAGIC, 0x07, struct penglai_enclave_user_param)
 
-
+#define DEFAULT_SECURE_PAGES_ORDER 10
 #define DEFAULT_CLOCK_DELAY 100000
 #define DEFAULT_UNTRUSTED_PTR   0x0000001000000000
 #define ENCLAVE_DEFAULT_KBUFFER_SIZE              0x1000UL
@@ -48,10 +50,12 @@ struct penglai_enclave_sbi_param
 	unsigned long size;
 	unsigned long entry_point;
 	unsigned long untrusted_ptr;
+	unsigned long untrusted_paddr;
 	unsigned long untrusted_size;
 	unsigned long free_mem;
 	//enclave shared mem with kernel
 	unsigned long kbuffer;
+	unsigned long kbuffer_paddr;
 	unsigned long kbuffer_size;
 	unsigned long *ecall_arg0;
 	unsigned long *ecall_arg1;
@@ -106,6 +110,13 @@ struct penglai_enclave_ioctl_attest_enclave
 	unsigned long eid;
 	unsigned long nonce;
 	struct report_t report;
+};
+
+struct mm_reclaim_arg_t
+{
+  unsigned long req_size;
+  unsigned long req_addr;
+  unsigned long resp_size;
 };
 
 long penglai_enclave_ioctl(struct file* filep, unsigned int cmd, unsigned long args);

--- a/penglai-enclave-driver/penglai-enclave-page.h
+++ b/penglai-enclave-driver/penglai-enclave-page.h
@@ -22,6 +22,13 @@ typedef uintptr_t vaddr_t;
 typedef uintptr_t paddr_t;
 typedef unsigned long pt_entry_t;
 
+// #define PENGLAI_DEBUG
+#ifdef PENGLAI_DEBUG
+#define dprint(...) printk(__VA_ARGS__)
+#else
+#define dprint(...)
+#endif
+
 #define RISCV_PT_SHIFT 12
 #define RISCV_PT_LEVEL 3
 #define RISCV_PT_LEVELBITS 9

--- a/penglai-enclave-driver/penglai-enclave.c
+++ b/penglai-enclave-driver/penglai-enclave.c
@@ -62,10 +62,12 @@ enclave_t* create_enclave(int total_pages)
 		goto free_enclave;
 	}
 
-	printk("[Penglai Driver@%s] total_pages:%d order:%ld\n",
+	dprint("[Penglai Driver@%s] total_pages:%d order:%ld\n",
 			__func__, total_pages, order);
 	//Note: SBI_SM_ALLOC_ENCLAVE_MEM's arg is the num of bytes instead of pages
-	require_sec_memory->size = total_pages << RISCV_PGSHIFT;
+	require_sec_memory->size = total_pages << RISCV_PGSHIFT;//0x200000
+    dprint("[Penglai Driver@%s] require_sec_memory va: %lx, pa: %lx, __va(pa): %lx, size:%lx\n",
+			__func__, (unsigned long)require_sec_memory, __pa(require_sec_memory), (unsigned long)__va(__pa(require_sec_memory)),(unsigned long)require_sec_memory->size);
 
 	ret = SBI_CALL_1(SBI_SM_ALLOC_ENCLAVE_MEM, __pa(require_sec_memory));
 	pa = require_sec_memory->paddr;
@@ -83,7 +85,7 @@ enclave_t* create_enclave(int total_pages)
 			goto free_enclave;
 		}
 
-		ret = SBI_CALL_2(SBI_SM_MEMORY_EXTEND, __pa(addr), 4096 * (1 << order) );
+		ret = SBI_CALL_2(SBI_SM_MEMORY_EXTEND, __pa(addr), (1 << (order+RISCV_PGSHIFT)) );
 		if(ret.error)
 		{
 			printk("KERNEL MODULE: sbi call extend memory is failed\n");
@@ -125,7 +127,7 @@ free_enclave:
 	if(enclave_mem) kfree(enclave_mem);
 	if(untrusted_mem) kfree(untrusted_mem);
     if(require_sec_memory) kfree(require_sec_memory);
-
+	spin_unlock_bh(&kmalloc_enclave_lock);
 	return NULL;
 }
 

--- a/penglai-enclave-driver/penglai-enclave.h
+++ b/penglai-enclave-driver/penglai-enclave.h
@@ -28,11 +28,12 @@
 #define SBI_SM_DESTROY_ENCLAVE           94
 #define SBI_SM_ALLOC_ENCLAVE_MEM         93
 #define SBI_SM_MEMORY_EXTEND             92
-#define SBI_SM_MEMORY_RECLAIM      		 91
+#define SBI_SM_MEMORY_RECLAIM			 91
 #define SBI_SM_FREE_ENCLAVE_MEM          90
 #define SBI_SM_DEBUG_PRINT               88
 
 //Error codes of SBI_SM_ALLOC_ENCLAVE_MEM
+#define RETRY_SPIN_LOCK         		 -3
 #define ENCLAVE_NO_MEMORY                -2
 #define ENCLAVE_UNKNOWN_ERROR            -1
 #define ENCLAVE_SUCCESS                   0
@@ -87,6 +88,13 @@ typedef struct require_sec_memory
 	unsigned long paddr;
 	unsigned long resp_size;
 } require_sec_memory_t;
+
+typedef struct reclaim_sec_memory
+{
+	unsigned long size;
+	unsigned long paddr;
+	unsigned long resp_size;
+} reclaim_sec_memory_t;
 
 enclave_t* create_enclave(int total_pages);
 int destroy_enclave(enclave_t* enclave);


### PR DESCRIPTION
Fix the problem that metadata memory is not fully freed when clearing pmp

issues#100