### PR TITLE
make hash_enclave the same as sign_tool

### DIFF
--- a/opensbi-1.2/lib/sbi/sm/attest.c
+++ b/opensbi-1.2/lib/sbi/sm/attest.c
@@ -79,14 +79,14 @@ void hash_enclave(struct enclave_t *enclave, void* hash, uintptr_t nonce_arg)
     SM3_process(&hash_ctx, (unsigned char*)(&(enclave->entry_point)),
         sizeof(unsigned long));
     // configuration parameters
-    SM3_process(&hash_ctx, (unsigned char*)(&(enclave->untrusted_ptr)),
-        sizeof(unsigned long));
-    SM3_process(&hash_ctx, (unsigned char*)(&(enclave->untrusted_size)),
-        sizeof(unsigned long));
-    SM3_process(&hash_ctx, (unsigned char*)(&(enclave->kbuffer)),
-        sizeof(unsigned long));
-    SM3_process(&hash_ctx, (unsigned char*)(&(enclave->kbuffer_size)),
-        sizeof(unsigned long));
+    // SM3_process(&hash_ctx, (unsigned char*)(&(enclave->untrusted_ptr)),
+    //     sizeof(unsigned long));
+    // SM3_process(&hash_ctx, (unsigned char*)(&(enclave->untrusted_size)),
+    //     sizeof(unsigned long));
+    // SM3_process(&hash_ctx, (unsigned char*)(&(enclave->kbuffer)),
+    //     sizeof(unsigned long));
+    // SM3_process(&hash_ctx, (unsigned char*)(&(enclave->kbuffer_size)),
+    //     sizeof(unsigned long));
     hash_enclave_mem(
         &hash_ctx,
         (pte_t*)(enclave->thread_context.encl_ptbr << RISCV_PGSHIFT),


### PR DESCRIPTION
Comment four lines in `hash_enclave` to make it the same as sign_tool's `hash_enclave`.